### PR TITLE
Issue #28 DetailViewController.swift の冒頭に古いファイル名が残っている。：

### DIFF
--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController2.swift
+//  DetailViewController.swift
 //  iOSEngineerCodeCheck
 //
 //  Created by 史 翔新 on 2020/04/21.


### PR DESCRIPTION
ファイル冒頭コメントのファイル名がリネーム前のファイル名だった問題を修正しました。