### PR TITLE
Issue #33 [バグ] クロージャ内で循環参照が発生している：

### DIFF
--- a/iOSEngineerCodeCheck/ViewController.swift
+++ b/iOSEngineerCodeCheck/ViewController.swift
@@ -45,9 +45,10 @@ class ViewController: UITableViewController, UISearchBarDelegate {
     private func searchRepositories(for searchWord: String) {
         searchUrl = "https://api.github.com/search/repositories?q=\(searchWord)"
         searchTask = URLSession.shared.dataTask(with: URL(string: searchUrl)!) {
+            [weak self]
             (data, response, error) in
             guard let data = data else { return }
-            self.parseData(data)
+            self?.parseData(data)
         }
         searchTask?.resume()
     }


### PR DESCRIPTION
URLSession クラスのクロージャでメモリリークが起こるコードがあるため、weak をつけて循環参照をなくしました。