### PR TITLE
Issue #56 リポジトリ詳細画面をlandscapeにすると下部テキストが見切れる：

### DIFF
--- a/iOSEngineerCodeCheck/Info.plist
+++ b/iOSEngineerCodeCheck/Info.plist
@@ -50,15 +50,11 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
iPhone, iPad ともに、画面回転せずに縦画面固定のレイアウトとすることで対応しました。