### PR TITLE
Fix/issue78 apply single responsibility

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		BFD94601244DC5EC0012785A /* iOSEngineerCodeCheckUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD94600244DC5EC0012785A /* iOSEngineerCodeCheckUITests.swift */; };
 		C6835D1D2CE03EE000CCF57C /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6835D1C2CE03EE000CCF57C /* SearchService.swift */; };
 		C6835D212CE03FF200CCF57C /* ImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6835D202CE03FF200CCF57C /* ImageService.swift */; };
+		C6835D272CE0508900CCF57C /* RepositoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6835D262CE0508900CCF57C /* RepositoryManager.swift */; };
 		C6E53FC42CDF5E49001E078A /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E53FC32CDF5E49001E078A /* Repository.swift */; };
 /* End PBXBuildFile section */
 
@@ -56,6 +57,7 @@
 		BFD94602244DC5EC0012785A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C6835D1C2CE03EE000CCF57C /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
 		C6835D202CE03FF200CCF57C /* ImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
+		C6835D262CE0508900CCF57C /* RepositoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryManager.swift; sourceTree = "<group>"; };
 		C6E53FC32CDF5E49001E078A /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -110,6 +112,7 @@
 				BFD945DE244DC5E80012785A /* AppDelegate.swift */,
 				C6E53FC32CDF5E49001E078A /* Repository.swift */,
 				C6835D1C2CE03EE000CCF57C /* SearchService.swift */,
+				C6835D262CE0508900CCF57C /* RepositoryManager.swift */,
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
 				BFD945E2244DC5E80012785A /* ViewController.swift */,
 				C6835D202CE03FF200CCF57C /* ImageService.swift */,
@@ -277,6 +280,7 @@
 				C6E53FC42CDF5E49001E078A /* Repository.swift in Sources */,
 				C6835D1D2CE03EE000CCF57C /* SearchService.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
+				C6835D272CE0508900CCF57C /* RepositoryManager.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 				C6835D212CE03FF200CCF57C /* ImageService.swift in Sources */,
 			);

--- a/iOSEngineerCodeCheck/RepositoryManager.swift
+++ b/iOSEngineerCodeCheck/RepositoryManager.swift
@@ -1,7 +1,7 @@
 //
 //  RepositoryManager.swift
 //  iOSEngineerCodeCheck
-//  
+//
 //  Created by taro-taryo on 2024/11/10.
 // Copyright © 2024 YUMEMI Inc. All rights reserved.
 // Copyright © 2024 taro-taryo. All rights reserved.

--- a/iOSEngineerCodeCheck/RepositoryManager.swift
+++ b/iOSEngineerCodeCheck/RepositoryManager.swift
@@ -1,0 +1,31 @@
+//
+//  RepositoryManager.swift
+//  iOSEngineerCodeCheck
+//  
+//  Created by taro-taryo on 2024/11/10.
+// Copyright © 2024 YUMEMI Inc. All rights reserved.
+// Copyright © 2024 taro-taryo. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+class RepositoryManager {
+    private let searchService = SearchService()
+
+    func fetchRepositories(
+        for searchWord: String, completion: @escaping (Result<[Repository], Error>) -> Void
+    ) {
+        searchService.searchRepositories(for: searchWord, completion: completion)
+    }
+}

--- a/iOSEngineerCodeCheck/ViewController.swift
+++ b/iOSEngineerCodeCheck/ViewController.swift
@@ -13,7 +13,7 @@ class ViewController: UITableViewController, UISearchBarDelegate {
     @IBOutlet weak var searchBar: UISearchBar!
 
     var repositories: [Repository] = []
-    private let searchService = SearchService()
+    private let repositoryManager = RepositoryManager()
     var selectedIndex: Int?
 
     override func viewDidLoad() {
@@ -35,7 +35,7 @@ class ViewController: UITableViewController, UISearchBarDelegate {
     }
 
     private func fetchRepositories(for searchWord: String) {
-        searchService.searchRepositories(for: searchWord) { [weak self] result in
+        repositoryManager.fetchRepositories(for: searchWord) { [weak self] result in
             switch result {
             case .success(let repositories):
                 self?.updateRepositories(with: repositories)


### PR DESCRIPTION
Issue # 78 単一責任原則違反の修正：
・ViewController 内でデータ処理とUI更新を分離しました。
・データ処理とAPIの取得部分は新しい RepositoryManager クラスに移しました