### PR TITLE
Issue #79 インターフェース分離の原則違反の修正：

### DIFF
--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -19,7 +19,17 @@ class DetailViewController: UIViewController {
     @IBOutlet weak var issuesLabel: UILabel!
 
     var repository: Repository?
-    private let imageService = ImageService()
+    private let imageService: ImageFetchable
+
+    init(imageService: ImageFetchable = ImageService()) {
+        self.imageService = imageService
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        self.imageService = ImageService()
+        super.init(coder: coder)
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/iOSEngineerCodeCheck/ImageService.swift
+++ b/iOSEngineerCodeCheck/ImageService.swift
@@ -20,7 +20,11 @@
 
 import UIKit
 
-class ImageService {
+protocol ImageFetchable {
+    func fetchImage(from urlString: String, completion: @escaping (UIImage?) -> Void)
+}
+
+class ImageService: ImageFetchable {
     func fetchImage(from urlString: String, completion: @escaping (UIImage?) -> Void) {
         guard let url = URL(string: urlString) else {
             completion(nil)

--- a/iOSEngineerCodeCheck/RepositoryManager.swift
+++ b/iOSEngineerCodeCheck/RepositoryManager.swift
@@ -20,12 +20,12 @@
 
 import Foundation
 
-class RepositoryManager {
+class RepositoryManager: RepositoryFetchable {
     private let searchService = SearchService()
 
     func fetchRepositories(
         for searchWord: String, completion: @escaping (Result<[Repository], Error>) -> Void
     ) {
-        searchService.searchRepositories(for: searchWord, completion: completion)
+        searchService.fetchRepositories(for: searchWord, completion: completion)
     }
 }

--- a/iOSEngineerCodeCheck/SearchService.swift
+++ b/iOSEngineerCodeCheck/SearchService.swift
@@ -20,8 +20,14 @@
 
 import Foundation
 
-class SearchService {
-    func searchRepositories(
+protocol RepositoryFetchable {
+    func fetchRepositories(
+        for searchWord: String, completion: @escaping (Result<[Repository], Error>) -> Void
+    )
+}
+
+class SearchService: RepositoryFetchable {
+    func fetchRepositories(
         for searchWord: String, completion: @escaping (Result<[Repository], Error>) -> Void
     ) {
         let urlString = "https://api.github.com/search/repositories?q=\(searchWord)"

--- a/iOSEngineerCodeCheck/ViewController.swift
+++ b/iOSEngineerCodeCheck/ViewController.swift
@@ -13,8 +13,18 @@ class ViewController: UITableViewController, UISearchBarDelegate {
     @IBOutlet weak var searchBar: UISearchBar!
 
     var repositories: [Repository] = []
-    private let repositoryManager = RepositoryManager()
+    private let repositoryManager: RepositoryFetchable
     var selectedIndex: Int?
+
+    init(repositoryManager: RepositoryFetchable = RepositoryManager()) {
+        self.repositoryManager = repositoryManager
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        self.repositoryManager = RepositoryManager()
+        super.init(coder: coder)
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
・RepositoryFetchable プロトコルを定義し、リポジトリのデータ取得に必要なインターフェイスのみを提供しました。 ・ImageFetchable プロトコルを定義し、画像取得に必要なインターフェイスのみを提供しました。 ・クラスが依存するプロトコルを必要最小限のものに限定しました。