### PR TITLE
Issue #111 テスト実装：

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		C61A4EF12CE0D481004F3E27 /* StubImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61A4EF02CE0D481004F3E27 /* StubImageService.swift */; };
 		C61A4EF32CE0D490004F3E27 /* StubSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61A4EF22CE0D490004F3E27 /* StubSearchService.swift */; };
 		C61A4EF52CE0D4A4004F3E27 /* Repository+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61A4EF42CE0D4A4004F3E27 /* Repository+Stub.swift */; };
+		C61A4EF72CE1993B004F3E27 /* AppErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61A4EF62CE1993A004F3E27 /* AppErrorTests.swift */; };
+		C61A4EF92CE19951004F3E27 /* NetworkErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61A4EF82CE1994F004F3E27 /* NetworkErrorTests.swift */; };
 		C64030B72CE0CFCE0026BE3D /* RepositoryFetchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6835D362CE06A7900CCF57C /* RepositoryFetchable.swift */; };
 		C64030B82CE0CFCE0026BE3D /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65049832CE0B52000507163 /* NetworkError.swift */; };
 		C64030B92CE0CFCE0026BE3D /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E53FC32CDF5E49001E078A /* Repository.swift */; };
@@ -108,6 +110,8 @@
 		C61A4EF02CE0D481004F3E27 /* StubImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubImageService.swift; sourceTree = "<group>"; };
 		C61A4EF22CE0D490004F3E27 /* StubSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubSearchService.swift; sourceTree = "<group>"; };
 		C61A4EF42CE0D4A4004F3E27 /* Repository+Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Repository+Stub.swift"; sourceTree = "<group>"; };
+		C61A4EF62CE1993A004F3E27 /* AppErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorTests.swift; sourceTree = "<group>"; };
+		C61A4EF82CE1994F004F3E27 /* NetworkErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorTests.swift; sourceTree = "<group>"; };
 		C64030DD2CE0D1660026BE3D /* RepositoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryListViewModelTests.swift; sourceTree = "<group>"; };
 		C64030DF2CE0D1860026BE3D /* ImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoaderTests.swift; sourceTree = "<group>"; };
 		C64030E12CE0D19D0026BE3D /* RepositoryManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryManagerTests.swift; sourceTree = "<group>"; };
@@ -202,6 +206,8 @@
 				C64030DF2CE0D1860026BE3D /* ImageLoaderTests.swift */,
 				C64030E12CE0D19D0026BE3D /* RepositoryManagerTests.swift */,
 				C64030E32CE0D1B20026BE3D /* SearchServiceTests.swift */,
+				C61A4EF62CE1993A004F3E27 /* AppErrorTests.swift */,
+				C61A4EF82CE1994F004F3E27 /* NetworkErrorTests.swift */,
 				BFD945F7244DC5EB0012785A /* Info.plist */,
 			);
 			path = iOSEngineerCodeCheckTests;
@@ -530,6 +536,7 @@
 				C64030DE2CE0D1670026BE3D /* RepositoryListViewModelTests.swift in Sources */,
 				C64030BE2CE0CFCE0026BE3D /* iOSEngineerCodeCheckApp.swift in Sources */,
 				C61A4EF12CE0D481004F3E27 /* StubImageService.swift in Sources */,
+				C61A4EF72CE1993B004F3E27 /* AppErrorTests.swift in Sources */,
 				C64030BF2CE0CFCE0026BE3D /* DIContainer.swift in Sources */,
 				C64030C02CE0CFCE0026BE3D /* DetailView.swift in Sources */,
 				C64030C12CE0CFCE0026BE3D /* RepositoriesResponse.swift in Sources */,
@@ -538,6 +545,7 @@
 				C64030C32CE0CFCE0026BE3D /* AppError.swift in Sources */,
 				C64030C42CE0CFCE0026BE3D /* RepositoryRow.swift in Sources */,
 				C64030C52CE0CFCE0026BE3D /* KeyboardAvoider.swift in Sources */,
+				C61A4EF92CE19951004F3E27 /* NetworkErrorTests.swift in Sources */,
 				C64030C62CE0CFCE0026BE3D /* ServiceLocator.swift in Sources */,
 				C64030C72CE0CFCE0026BE3D /* RepositoryManager.swift in Sources */,
 				C64030C82CE0CFCE0026BE3D /* SearchService.swift in Sources */,

--- a/iOSEngineerCodeCheckTests/AppErrorTests.swift
+++ b/iOSEngineerCodeCheckTests/AppErrorTests.swift
@@ -1,0 +1,34 @@
+//
+//  AppErrorTests.swift
+//  iOSEngineerCodeCheck
+//  
+//  Created by taro-taryo on 2024/11/11.
+// Copyright © 2024 YUMEMI Inc. All rights reserved.
+// Copyright © 2024 taro-taryo. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+@testable import iOSEngineerCodeCheck
+
+class AppErrorTests: XCTestCase {
+    func testNetworkErrorDescription() {
+        let error = AppError.network(.invalidURL)
+        XCTAssertEqual(error.localizedDescription, "The URL provided was invalid.")
+    }
+
+    func testUnknownErrorDescription() {
+        let error = AppError.unknown("Unknown error")
+        XCTAssertEqual(error.localizedDescription, "Unknown error")
+    }
+}

--- a/iOSEngineerCodeCheckTests/ImageLoaderTests.swift
+++ b/iOSEngineerCodeCheckTests/ImageLoaderTests.swift
@@ -20,11 +20,9 @@
 
 import UIKit
 import XCTest
-
 @testable import iOSEngineerCodeCheck
 
 class ImageLoaderTests: XCTestCase {
-
     var imageLoader: ImageLoader!
     var stubImageService: StubImageService!
 
@@ -42,8 +40,8 @@ class ImageLoaderTests: XCTestCase {
 
     func testLoadImageWithValidURL() {
         let expectation = XCTestExpectation(description: "Image loaded successfully")
-
         stubImageService.image = UIImage()
+
         imageLoader.loadImage(from: "validURL")
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -56,13 +54,15 @@ class ImageLoaderTests: XCTestCase {
 
     func testLoadImageWithInvalidURL() {
         let expectation = XCTestExpectation(description: "Image loading failed with nil")
-        stubImageService.shouldReturnError = true  // エラーを強制してnilを返すように設定
+        stubImageService.shouldReturnError = true
 
         imageLoader.loadImage(from: "invalidURL")
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             XCTAssertNil(self.imageLoader.image)
             expectation.fulfill()
         }
+
         wait(for: [expectation], timeout: 1.0)
     }
 

--- a/iOSEngineerCodeCheckTests/NetworkErrorTests.swift
+++ b/iOSEngineerCodeCheckTests/NetworkErrorTests.swift
@@ -1,0 +1,39 @@
+//
+//  NetworkErrorTests.swift
+//  iOSEngineerCodeCheck
+//  
+//  Created by taro-taryo on 2024/11/11.
+// Copyright © 2024 YUMEMI Inc. All rights reserved.
+// Copyright © 2024 taro-taryo. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+@testable import iOSEngineerCodeCheck
+
+class NetworkErrorTests: XCTestCase {
+    func testInvalidURLErrorDescription() {
+        let error = NetworkError.invalidURL
+        XCTAssertEqual(error.localizedDescription, "The URL provided was invalid.")
+    }
+
+    func testNoDataErrorDescription() {
+        let error = NetworkError.noData
+        XCTAssertEqual(error.localizedDescription, "No data was received from the server.")
+    }
+
+    func testRequestFailedErrorDescription() {
+        let error = NetworkError.requestFailed(NSError(domain: "", code: -1009, userInfo: [NSLocalizedDescriptionKey: "Network error"]))
+        XCTAssertEqual(error.localizedDescription, "Request failed with error: Network error")
+    }
+}

--- a/iOSEngineerCodeCheckTests/RepositoryManagerTests.swift
+++ b/iOSEngineerCodeCheckTests/RepositoryManagerTests.swift
@@ -19,11 +19,9 @@
 //
 
 import XCTest
-
 @testable import iOSEngineerCodeCheck
 
 class RepositoryManagerTests: XCTestCase {
-
     var repositoryManager: RepositoryManager!
     var stubSearchService: StubSearchService!
 
@@ -41,8 +39,8 @@ class RepositoryManagerTests: XCTestCase {
 
     func testFetchRepositoriesSuccess() {
         let expectation = XCTestExpectation(description: "Repositories fetched successfully")
-
         stubSearchService.result = .success([Repository.stub()])
+
         repositoryManager.fetchRepositories(for: "swift") { result in
             if case .success(let repositories) = result {
                 XCTAssertEqual(repositories.count, 1)
@@ -56,12 +54,11 @@ class RepositoryManagerTests: XCTestCase {
 
     func testFetchRepositoriesFailure() {
         let expectation = XCTestExpectation(description: "Repositories fetch failed with error")
-
         stubSearchService.result = .failure(AppError.network(.invalidURL))
+
         repositoryManager.fetchRepositories(for: "invalid") { result in
             if case .failure(let error) = result {
-                XCTAssertEqual(
-                    error.localizedDescription, AppError.network(.invalidURL).localizedDescription)
+                XCTAssertEqual(error.localizedDescription, AppError.network(.invalidURL).localizedDescription)
                 expectation.fulfill()
             }
         }
@@ -74,8 +71,7 @@ class RepositoryManagerTests: XCTestCase {
 
         repositoryManager.fetchRepositories(for: "") { result in
             if case .failure(let error) = result {
-                XCTAssertEqual(
-                    error.localizedDescription, AppError.network(.invalidURL).localizedDescription)
+                XCTAssertEqual(error.localizedDescription, AppError.network(.invalidURL).localizedDescription)
                 expectation.fulfill()
             }
         }

--- a/iOSEngineerCodeCheckTests/iOSEngineerCodeCheckTests.swift
+++ b/iOSEngineerCodeCheckTests/iOSEngineerCodeCheckTests.swift
@@ -7,47 +7,53 @@
 //
 
 import XCTest
-
 @testable import iOSEngineerCodeCheck
 
 class iOSEngineerCodeCheckTests: XCTestCase {
-
-    let repositoryManagerTests = RepositoryManagerTests()
-    let repositoryListViewModelTests = RepositoryListViewModelTests()
-    let searchServiceTests = SearchServiceTests()
-    let imageLoaderTests = ImageLoaderTests()
-
-    override func setUpWithError() throws {
-        // 各テストクラスのセットアップメソッドを呼び出し
-        try super.setUpWithError()
-        repositoryManagerTests.setUp()
-        repositoryListViewModelTests.setUp()
-        searchServiceTests.setUp()
-        imageLoaderTests.setUp()
-    }
-
-    override func tearDownWithError() throws {
-        // 各テストクラスのクリーンアップメソッドを呼び出し
-        repositoryManagerTests.tearDown()
-        repositoryListViewModelTests.tearDown()
-        searchServiceTests.tearDown()
-        imageLoaderTests.tearDown()
-        try super.tearDownWithError()
-    }
-
+    
     func testAll() throws {
-        // 各テストクラスのテストメソッドを実行
+        // RepositoryManagerTests
+        let repositoryManagerTests = RepositoryManagerTests()
+        repositoryManagerTests.setUp()
         repositoryManagerTests.testFetchRepositoriesSuccess()
         repositoryManagerTests.testFetchRepositoriesFailure()
+        repositoryManagerTests.testEmptySearchWordReturnsError()
+        repositoryManagerTests.tearDown()
+
+        // RepositoryListViewModelTests
+        let repositoryListViewModelTests = RepositoryListViewModelTests()
+        repositoryListViewModelTests.setUp()
         repositoryListViewModelTests.testFetchRepositoriesWithValidSearchText()
         repositoryListViewModelTests.testFetchRepositoriesWithInvalidSearchText()
         repositoryListViewModelTests.testSearchRepositoriesUpdatesRepositories()
         repositoryListViewModelTests.testEmptySearchTextReturnsError()
+        repositoryListViewModelTests.tearDown()
+
+        // SearchServiceTests
+        let searchServiceTests = SearchServiceTests()
+        searchServiceTests.setUp()
         searchServiceTests.testFetchRepositoriesSuccess()
         searchServiceTests.testFetchRepositoriesInvalidURL()
         searchServiceTests.testFetchRepositoriesRequestFailed()
+        searchServiceTests.tearDown()
+
+        // ImageLoaderTests
+        let imageLoaderTests = ImageLoaderTests()
+        imageLoaderTests.setUp()
         imageLoaderTests.testLoadImageWithValidURL()
         imageLoaderTests.testLoadImageWithInvalidURL()
         imageLoaderTests.testLoadImageWithNilURL()
+        imageLoaderTests.tearDown()
+
+        // AppErrorTests
+        let appErrorTests = AppErrorTests()
+        appErrorTests.testNetworkErrorDescription()
+        appErrorTests.testUnknownErrorDescription()
+
+        // NetworkErrorTests
+        let networkErrorTests = NetworkErrorTests()
+        networkErrorTests.testInvalidURLErrorDescription()
+        networkErrorTests.testNoDataErrorDescription()
+        networkErrorTests.testRequestFailedErrorDescription()
     }
 }


### PR DESCRIPTION
Clean Architectureに従った形でテストを書き直しました。
各クラスの責務に基づき、依存関係をスタブやモックで置き換えて単体テストを実施できる構成にしています。