### PR TITLE
Issue #182 インクリメンタルサジェスト強化 #182

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -114,6 +114,12 @@
 		C6BFEF262CE3233F008304B3 /* RepositoryBadgeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BFEF252CE3233E008304B3 /* RepositoryBadgeViewTests.swift */; };
 		C6BFEF282CE32360008304B3 /* RepositoryRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BFEF272CE32359008304B3 /* RepositoryRowTests.swift */; };
 		C6BFEF2A2CE3237E008304B3 /* RepositoryRowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BFEF292CE3237C008304B3 /* RepositoryRowUITests.swift */; };
+		C6BFEF2C2CE326CE008304B3 /* EnhancedSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BFEF2B2CE326CD008304B3 /* EnhancedSearchService.swift */; };
+		C6BFEF2D2CE326CE008304B3 /* EnhancedSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BFEF2B2CE326CD008304B3 /* EnhancedSearchService.swift */; };
+		C6BFEF2E2CE326CE008304B3 /* EnhancedSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BFEF2B2CE326CD008304B3 /* EnhancedSearchService.swift */; };
+		C6BFEF302CE32AE0008304B3 /* MockEnhancedSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BFEF2F2CE32ADF008304B3 /* MockEnhancedSearchService.swift */; };
+		C6BFEF322CE32AFB008304B3 /* MockFetchRepositoriesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BFEF312CE32AFA008304B3 /* MockFetchRepositoriesUseCase.swift */; };
+		C6BFEF342CE32B1E008304B3 /* ContentViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BFEF332CE32B18008304B3 /* ContentViewUITests.swift */; };
 		C6C6F5722CE30FEE00ACC55C /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = C6C6F5712CE30FEE00ACC55C /* Localizable.xcstrings */; };
 		C6E53FC42CDF5E49001E078A /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E53FC32CDF5E49001E078A /* Repository.swift */; };
 /* End PBXBuildFile section */
@@ -191,6 +197,10 @@
 		C6BFEF252CE3233E008304B3 /* RepositoryBadgeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryBadgeViewTests.swift; sourceTree = "<group>"; };
 		C6BFEF272CE32359008304B3 /* RepositoryRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryRowTests.swift; sourceTree = "<group>"; };
 		C6BFEF292CE3237C008304B3 /* RepositoryRowUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryRowUITests.swift; sourceTree = "<group>"; };
+		C6BFEF2B2CE326CD008304B3 /* EnhancedSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedSearchService.swift; sourceTree = "<group>"; };
+		C6BFEF2F2CE32ADF008304B3 /* MockEnhancedSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEnhancedSearchService.swift; sourceTree = "<group>"; };
+		C6BFEF312CE32AFA008304B3 /* MockFetchRepositoriesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFetchRepositoriesUseCase.swift; sourceTree = "<group>"; };
+		C6BFEF332CE32B18008304B3 /* ContentViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewUITests.swift; sourceTree = "<group>"; };
 		C6C6F5712CE30FEE00ACC55C /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		C6E53FC32CDF5E49001E078A /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -280,6 +290,7 @@
 				C65F476D2CE1F1E8007F8AD9 /* Stub */,
 				BFD94600244DC5EC0012785A /* iOSEngineerCodeCheckUITests.swift */,
 				C6BFEF292CE3237C008304B3 /* RepositoryRowUITests.swift */,
+				C6BFEF332CE32B18008304B3 /* ContentViewUITests.swift */,
 				BFD94602244DC5EC0012785A /* Info.plist */,
 			);
 			path = iOSEngineerCodeCheckUITests;
@@ -292,6 +303,8 @@
 				C61A4EF02CE0D481004F3E27 /* StubImageService.swift */,
 				C61A4EF22CE0D490004F3E27 /* StubSearchService.swift */,
 				C61A4EF42CE0D4A4004F3E27 /* Repository+Stub.swift */,
+				C6BFEF2F2CE32ADF008304B3 /* MockEnhancedSearchService.swift */,
+				C6BFEF312CE32AFA008304B3 /* MockFetchRepositoriesUseCase.swift */,
 			);
 			path = Stub;
 			sourceTree = "<group>";
@@ -321,6 +334,7 @@
 				C68F7AFB2CE2FB1700364D51 /* RepositoryDataSource.swift */,
 				C6835D262CE0508900CCF57C /* RepositoryManager.swift */,
 				C6835D1C2CE03EE000CCF57C /* SearchService.swift */,
+				C6BFEF2B2CE326CD008304B3 /* EnhancedSearchService.swift */,
 			);
 			path = DataSource;
 			sourceTree = "<group>";
@@ -615,6 +629,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C6BFEF2E2CE326CE008304B3 /* EnhancedSearchService.swift in Sources */,
 				C68F7B032CE2FC5800364D51 /* ImageFetchable.swift in Sources */,
 				C6835D2F2CE0660500CCF57C /* RepositoryListViewModel.swift in Sources */,
 				C6835D372CE06A7900CCF57C /* RepositoryFetchable.swift in Sources */,
@@ -659,6 +674,7 @@
 				C64030B82CE0CFCE0026BE3D /* NetworkError.swift in Sources */,
 				C61A4EF32CE0D490004F3E27 /* StubSearchService.swift in Sources */,
 				C64030B92CE0CFCE0026BE3D /* Repository.swift in Sources */,
+				C6BFEF2C2CE326CE008304B3 /* EnhancedSearchService.swift in Sources */,
 				C68F7AF42CE2F97900364D51 /* FetchRepositoriesUseCase.swift in Sources */,
 				C64030BA2CE0CFCE0026BE3D /* RepositoryError.swift in Sources */,
 				C64030BB2CE0CFCE0026BE3D /* ImageLoader.swift in Sources */,
@@ -677,6 +693,7 @@
 				C61A4EF72CE1993B004F3E27 /* AppErrorTests.swift in Sources */,
 				C64030BF2CE0CFCE0026BE3D /* DIContainer.swift in Sources */,
 				C64030C02CE0CFCE0026BE3D /* DetailView.swift in Sources */,
+				C6BFEF322CE32AFB008304B3 /* MockFetchRepositoriesUseCase.swift in Sources */,
 				C64030C12CE0CFCE0026BE3D /* RepositoriesResponse.swift in Sources */,
 				C61A4EEF2CE0D467004F3E27 /* StubRepositoryManager.swift in Sources */,
 				C69EBF322CE2FE9500D7B272 /* RepositoryViewData.swift in Sources */,
@@ -688,6 +705,7 @@
 				C64030C62CE0CFCE0026BE3D /* ServiceLocator.swift in Sources */,
 				C64030C72CE0CFCE0026BE3D /* RepositoryManager.swift in Sources */,
 				C64030C82CE0CFCE0026BE3D /* SearchService.swift in Sources */,
+				C6BFEF302CE32AE0008304B3 /* MockEnhancedSearchService.swift in Sources */,
 				C6A236C62CE23AE9009ADF49 /* LanguageIconProvider.swift in Sources */,
 				C68F7AF72CE2F98700364D51 /* FetchImageUseCase.swift in Sources */,
 				C64030E42CE0D1B20026BE3D /* SearchServiceTests.swift in Sources */,
@@ -712,6 +730,8 @@
 				C6A236CA2CE23AF5009ADF49 /* UIConstants.swift in Sources */,
 				C64030CB2CE0CFCE0026BE3D /* DIContainer.swift in Sources */,
 				C64030CC2CE0CFCE0026BE3D /* (null) in Sources */,
+				C6BFEF2D2CE326CE008304B3 /* EnhancedSearchService.swift in Sources */,
+				C6BFEF342CE32B1E008304B3 /* ContentViewUITests.swift in Sources */,
 				C69EBF332CE2FE9500D7B272 /* RepositoryViewData.swift in Sources */,
 				C68F7AF32CE2F97900364D51 /* FetchRepositoriesUseCase.swift in Sources */,
 				C64030CD2CE0CFCE0026BE3D /* ImageLoader.swift in Sources */,

--- a/iOSEngineerCodeCheck/Data/DataSource/EnhancedSearchService.swift
+++ b/iOSEngineerCodeCheck/Data/DataSource/EnhancedSearchService.swift
@@ -1,0 +1,76 @@
+//
+//  EnhancedSearchService.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by taro-taryo on 2024/11/12.
+// Copyright © 2024 YUMEMI Inc. All rights reserved.
+// Copyright © 2024 taro-taryo. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+protocol EnhancedSearchServiceProtocol {
+    func fetchTopicSuggestions(
+        for query: String, completion: @escaping (Result<[String], Error>) -> Void)
+}
+
+class EnhancedSearchService: EnhancedSearchServiceProtocol {
+    func fetchTopicSuggestions(
+        for query: String, completion: @escaping (Result<[String], Error>) -> Void
+    ) {
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            completion(.success([]))
+            return
+        }
+
+        let urlString = "https://api.github.com/search/topics?q=\(query)&per_page=10"
+        guard
+            let encodedURLString = urlString.addingPercentEncoding(
+                withAllowedCharacters: .urlQueryAllowed),
+            let url = URL(string: encodedURLString)
+        else {
+            completion(.failure(AppError.network(.invalidURL)))
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.addValue("application/vnd.github.mercy-preview+json", forHTTPHeaderField: "Accept")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(AppError.network(.requestFailed(error))))
+                return
+            }
+            guard let data = data else {
+                completion(.failure(AppError.network(.noData)))
+                return
+            }
+            do {
+                let decodedResponse = try JSONDecoder().decode(TopicResponse.self, from: data)
+                let topics = decodedResponse.items.map { $0.name }
+                completion(.success(topics))
+            } catch {
+                completion(.failure(AppError.unknown(error.localizedDescription)))
+            }
+        }.resume()
+    }
+}
+
+struct TopicResponse: Codable {
+    let items: [Topic]
+}
+
+struct Topic: Codable {
+    let name: String
+}

--- a/iOSEngineerCodeCheck/DependencyInjection/ServiceLocator.swift
+++ b/iOSEngineerCodeCheck/DependencyInjection/ServiceLocator.swift
@@ -22,17 +22,24 @@ import Foundation
 
 class ServiceLocator {
     static func configure(container: DIContainer = DIContainer.shared) {
+        // 依存サービスの順序を見直し、EnhancedSearchServiceを先に登録
+        container.register(
+            EnhancedSearchService() as EnhancedSearchServiceProtocol,
+            for: EnhancedSearchServiceProtocol.self)
+
         container.register(
             FetchRepositoriesUseCase(repositoryFetchable: RepositoryDataSource())
                 as FetchRepositoriesUseCaseProtocol, for: FetchRepositoriesUseCaseProtocol.self)
+
         container.register(
             FetchImageUseCase(imageFetchable: ImageService()) as FetchImageUseCaseProtocol,
             for: FetchImageUseCaseProtocol.self)
 
-        // RepositoryListViewModel の登録
         container.register(
             RepositoryListViewModel(
-                fetchRepositoriesUseCase: container.resolve(FetchRepositoriesUseCaseProtocol.self)),
+                fetchRepositoriesUseCase: container.resolve(FetchRepositoriesUseCaseProtocol.self),
+                enhancedSearchService: container.resolve(EnhancedSearchServiceProtocol.self)
+            ),
             for: RepositoryListViewModel.self
         )
     }

--- a/iOSEngineerCodeCheck/Domain/ViewModel/RepositoryListViewModel.swift
+++ b/iOSEngineerCodeCheck/Domain/ViewModel/RepositoryListViewModel.swift
@@ -25,39 +25,76 @@ class RepositoryListViewModel: ObservableObject {
     @Published var repositories: [RepositoryViewData] = []
     @Published var searchText: String = ""
     @Published var tagSuggestions: [String] = []
+    @Published var relatedSuggestions: [String] = []  // トピックベースの強化サジェスト
     @Published var error: AppError?
 
     private let fetchRepositoriesUseCase: FetchRepositoriesUseCaseProtocol
+    private let enhancedSearchService: EnhancedSearchServiceProtocol
     private let allTags = [
         "swift", "javascript", "python", "java", "ruby", "php", "c++", "c#", "go", "kotlin", "dart",
         "typescript", "html", "css", "shell", "rust", "scala", "julia", "r", "matlab",
     ]
+    private var cancellables = Set<AnyCancellable>()
 
     init(
         fetchRepositoriesUseCase: FetchRepositoriesUseCaseProtocol = DIContainer.shared.resolve(
-            FetchRepositoriesUseCaseProtocol.self)
+            FetchRepositoriesUseCaseProtocol.self),
+        enhancedSearchService: EnhancedSearchServiceProtocol = DIContainer.shared.resolve(
+            EnhancedSearchServiceProtocol.self)
     ) {
         self.fetchRepositoriesUseCase = fetchRepositoriesUseCase
+        self.enhancedSearchService = enhancedSearchService
+        setupSearchTextObserver()
+    }
+
+    private func setupSearchTextObserver() {
+        $searchText
+            .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+            .removeDuplicates()
+            .sink { [weak self] text in
+                self?.updateTagSuggestions(for: text)
+                self?.fetchRelatedSuggestions(for: text)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func updateTagSuggestions(for query: String) {
+        tagSuggestions = allTags.filter { $0.contains(query.lowercased()) }
+    }
+
+    private func fetchRelatedSuggestions(for query: String) {
+        enhancedSearchService.fetchTopicSuggestions(for: query) { [weak self] result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let suggestions):
+                    self?.relatedSuggestions = suggestions
+                case .failure(let error):
+                    if let appError = error as? AppError {
+                        self?.error = appError
+                    } else {
+                        self?.error = AppError.unknown(error.localizedDescription)
+                    }
+                }
+            }
+        }
     }
 
     func onSearchTextChanged(_ newText: String) {
         searchText = newText
-        updateTagSuggestions(for: newText)
-        if !newText.isEmpty { searchRepositories() }
+        if !newText.isEmpty {
+            searchRepositories()
+        }
     }
 
     func onSearchCancelled() {
         searchText = ""
         tagSuggestions = []
+        relatedSuggestions = []
     }
 
     func onTagSuggestionSelected(_ tag: String) {
         searchText = tag
         searchRepositories()
-    }
-
-    private func updateTagSuggestions(for query: String) {
-        tagSuggestions = allTags.filter { $0.contains(query.lowercased()) }
     }
 
     func searchRepositories() {

--- a/iOSEngineerCodeCheck/Localizable.xcstrings
+++ b/iOSEngineerCodeCheck/Localizable.xcstrings
@@ -115,6 +115,16 @@
         }
       }
     },
+    "ui_related_topics_title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "関連トピック"
+          }
+        }
+      }
+    },
     "ui_search_placeholder" : {
       "comment" : "General UI Texts",
       "extractionState" : "manual",
@@ -145,6 +155,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stars"
+          }
+        }
+      }
+    },
+    "ui_tag_suggestions_title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグ候補"
           }
         }
       }

--- a/iOSEngineerCodeCheck/Presentation/Screen/ContentView.swift
+++ b/iOSEngineerCodeCheck/Presentation/Screen/ContentView.swift
@@ -37,8 +37,8 @@ struct ContentView: View {
                 backgroundGradient
                 VStack(spacing: 16) {
                     searchBar
-                    if isIncrementalSearchMode && !viewModel.tagSuggestions.isEmpty {
-                        tagSuggestionsScrollView
+                    if isIncrementalSearchMode {
+                        suggestionsScrollView
                     }
                     searchResultsView
                 }
@@ -80,25 +80,59 @@ struct ContentView: View {
         .padding(.top, 10)
     }
 
-    private var tagSuggestionsScrollView: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 10) {
-                ForEach(viewModel.tagSuggestions, id: \.self) { suggestion in
-                    Button(action: {
-                        viewModel.onTagSuggestionSelected(suggestion)
-                        isIncrementalSearchMode = false
-                    }) {
-                        Text(suggestion)
-                            .foregroundColor(.white)
-                            .padding(.vertical, 8)
-                            .padding(.horizontal, 12)
-                            .background(Color.blue)
-                            .cornerRadius(15)
+    private var suggestionsScrollView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // タグ候補表示
+            if !viewModel.tagSuggestions.isEmpty {
+                Text(String(localized: "ui_tag_suggestions_title"))
+                    .font(.subheadline)
+                    .foregroundColor(.white)  // "検索結果"に合わせて白色に設定
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(viewModel.tagSuggestions, id: \.self) { suggestion in
+                            Button(action: {
+                                viewModel.onTagSuggestionSelected(suggestion)
+                                isIncrementalSearchMode = false
+                            }) {
+                                Text(suggestion)
+                                    .foregroundColor(.white)
+                                    .padding(.vertical, 8)
+                                    .padding(.horizontal, 12)
+                                    .background(Color.blue)
+                                    .cornerRadius(15)
+                            }
+                        }
                     }
+                    .padding(.horizontal)
                 }
             }
-            .padding(.horizontal)
+
+            // 強化版インクリメンタルサジェスト（トピックベース）表示
+            if !viewModel.relatedSuggestions.isEmpty {
+                Text(String(localized: "ui_related_topics_title"))
+                    .font(.subheadline)
+                    .foregroundColor(.white)  // "検索結果"に合わせて白色に設定
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(viewModel.relatedSuggestions, id: \.self) { suggestion in
+                            Button(action: {
+                                viewModel.onTagSuggestionSelected(suggestion)
+                                isIncrementalSearchMode = false
+                            }) {
+                                Text(suggestion)
+                                    .foregroundColor(.white)
+                                    .padding(.vertical, 8)
+                                    .padding(.horizontal, 12)
+                                    .background(Color.green)
+                                    .cornerRadius(15)
+                            }
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+            }
         }
+        .padding(.top, 8)
     }
 
     private var searchResultsView: some View {
@@ -107,7 +141,6 @@ struct ContentView: View {
                 .font(.headline)
                 .foregroundColor(.white)
                 .padding(.leading)
-
             if viewModel.repositories.isEmpty {
                 Text(String(localized: "ui_no_repositories_found"))
                     .foregroundColor(.white)

--- a/iOSEngineerCodeCheckTests/Stub/MockEnhancedSearchService.swift
+++ b/iOSEngineerCodeCheckTests/Stub/MockEnhancedSearchService.swift
@@ -1,0 +1,35 @@
+//
+//  MockEnhancedSearchService.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by taro-taryo on 2024/11/12.
+// Copyright © 2024 YUMEMI Inc. All rights reserved.
+// Copyright © 2024 taro-taryo. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+@testable import iOSEngineerCodeCheck
+
+class MockEnhancedSearchService: EnhancedSearchServiceProtocol {
+    var fetchSuggestionsResult: Result<[String], Error>?
+
+    func fetchTopicSuggestions(
+        for query: String, completion: @escaping (Result<[String], Error>) -> Void
+    ) {
+        if let result = fetchSuggestionsResult {
+            completion(result)
+        }
+    }
+}

--- a/iOSEngineerCodeCheckTests/Stub/MockFetchRepositoriesUseCase.swift
+++ b/iOSEngineerCodeCheckTests/Stub/MockFetchRepositoriesUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  MockFetchRepositoriesUseCase.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by taro-taryo on 2024/11/12.
+// Copyright © 2024 YUMEMI Inc. All rights reserved.
+// Copyright © 2024 taro-taryo. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+@testable import iOSEngineerCodeCheck
+
+class MockFetchRepositoriesUseCase: FetchRepositoriesUseCaseProtocol {
+    func execute(searchWord: String, completion: @escaping (Result<[Repository], Error>) -> Void) {
+    }
+}

--- a/iOSEngineerCodeCheckUITests/ContentViewUITests.swift
+++ b/iOSEngineerCodeCheckUITests/ContentViewUITests.swift
@@ -1,0 +1,102 @@
+//
+//  ContentViewUITests.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by taro-taryo on 2024/11/12.
+// Copyright © 2024 YUMEMI Inc. All rights reserved.
+// Copyright © 2024 taro-taryo. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+
+class ContentViewUITests: XCTestCase {
+
+    let app = XCUIApplication()
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app.launch()
+    }
+
+    func testTagSuggestionsAreDisplayedBasedOnSearchText() {
+        // Given
+        let searchBar = app.textFields["SearchBar"]
+        XCTAssertTrue(searchBar.exists)
+
+        // When
+        searchBar.tap()
+        searchBar.typeText("ja")
+
+        // Then
+        let tagSuggestion = app.buttons["swift"]  // タグ候補の例
+        XCTAssertTrue(
+            tagSuggestion.waitForExistence(timeout: 2.0),
+            "Tag suggestion should be visible based on input.")
+    }
+
+    func testRelatedTopicsAreDisplayedBasedOnSearchText() {
+        // Given
+        let searchBar = app.textFields["SearchBar"]
+        XCTAssertTrue(searchBar.exists)
+
+        // When
+        searchBar.tap()
+        searchBar.typeText("swift")
+
+        // Then
+        let relatedSuggestion = app.buttons["SwiftUI"]  // 取得した関連トピックの例
+        XCTAssertTrue(
+            relatedSuggestion.waitForExistence(timeout: 2.0),
+            "Related topic suggestion should be visible based on input.")
+    }
+
+    func testUserCanSelectTagSuggestion() {
+        // Given
+        let searchBar = app.textFields["SearchBar"]
+        searchBar.tap()
+        searchBar.typeText("ja")
+
+        // When
+        let tagSuggestion = app.buttons["swift"]  // タグ候補の例
+        XCTAssertTrue(
+            tagSuggestion.waitForExistence(timeout: 2.0), "Tag suggestion should be visible.")
+        tagSuggestion.tap()
+
+        // Then
+        let searchResults = app.tables["SearchResultsTable"]
+        XCTAssertTrue(
+            searchResults.exists,
+            "Search results should be displayed after selecting a tag suggestion.")
+    }
+
+    func testUserCanSelectRelatedTopicSuggestion() {
+        // Given
+        let searchBar = app.textFields["SearchBar"]
+        searchBar.tap()
+        searchBar.typeText("swift")
+
+        // When
+        let relatedSuggestion = app.buttons["SwiftUI"]  // 関連トピックの例
+        XCTAssertTrue(
+            relatedSuggestion.waitForExistence(timeout: 2.0),
+            "Related topic suggestion should be visible.")
+        relatedSuggestion.tap()
+
+        // Then
+        let searchResults = app.tables["SearchResultsTable"]
+        XCTAssertTrue(
+            searchResults.exists,
+            "Search results should be displayed after selecting a related topic suggestion.")
+    }
+}


### PR DESCRIPTION
- EnhancedSearchServiceを拡張し、GitHubトピック検索APIで関連トピックを取得する機能を追加
- RepositoryListViewModelで関連トピックのサジェストを提供
- ContentViewでタグ候補と関連トピック候補を分けて表示
- XCTestとXCUITestを追加し、サジェスト機能のテストを強化